### PR TITLE
fix: export default style

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Add the component to your Vue application:
 ```vue
 <script setup lang="ts">
 import VueMagnifier from '@websitebeaver/vue-magnifier'
+import '@websitebeaver/vue-magnifier/styles.css'
 </script>
 
 <template>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     ".": {
       "import": "./dist/vue-magnifier.es.js",
       "require": "./dist/vue-magnifier.umd.js"
-    }
+    },
+    "./style": "./dist/style.css"
   },
   "types": "./dist/install.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "import": "./dist/vue-magnifier.es.js",
       "require": "./dist/vue-magnifier.umd.js"
     },
-    "./style": "./dist/style.css"
+    "./styles.css": "./dist/style.css"
   },
   "types": "./dist/install.d.ts",
   "files": [


### PR DESCRIPTION
Vite libraries cannot inject css files, so they must be imported manually (for example, in main.ts). To make this possible, please add CSS export to package.json.

Also, it would be good to point out the need for manual import in README.md.

```ts
// main.ts
...
import '@websitebeaver/vue-magnifier/style'
...
```